### PR TITLE
Renderer fixed.

### DIFF
--- a/Makefile.main.psp
+++ b/Makefile.main.psp
@@ -1,0 +1,16 @@
+TARGET_LIB = libSDL2main.a
+
+OBJS= src/main/psp/SDL_psp_main.o
+
+INCDIR = ./include
+CFLAGS = -g -O2 -G0 -Wall -D__PSP__ -DHAVE_OPENGL
+CXXFLAGS = $(CFLAGS) -fno-exceptions -fno-rtti
+ASFLAGS = $(CFLAGS)
+
+LIBDIR  =
+LIBS = -lGL -lGLU -lglut -lz \
+         -lpspvfpu -lpsphprm -lpspsdk -lpspctrl -lpspumd -lpsprtc -lpsppower -lpspgum -lpspgu -lpspaudiolib -lpspaudio -lpsphttp -lpspssl -lpspwlan \
+         -lpspnet_adhocmatching -lpspnet_adhoc -lpspnet_adhocctl -lm -lpspvram
+
+PSPSDK=$(shell psp-config --pspsdk-path)
+include $(PSPSDK)/lib/build.mak

--- a/src/joystick/SDL_gamecontrollerdb.h
+++ b/src/joystick/SDL_gamecontrollerdb.h
@@ -669,6 +669,9 @@ static const char *s_ControllerMappings [] =
 #if defined(SDL_JOYSTICK_EMSCRIPTEN)
     "default,Standard Gamepad,a:b0,b:b1,back:b8,dpdown:b13,dpleft:b14,dpright:b15,dpup:b12,guide:b16,leftshoulder:b4,leftstick:b10,lefttrigger:b6,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:b7,rightx:a2,righty:a3,start:b9,x:b2,y:b3,",
 #endif
+#if defined(SDL_JOYSTICK_PSP)
+    "505350206275696c74696e206a6f7970,PSP builtin joypad,y:b0,b:b1,a:b2,x:b3,leftshoulder:b4,rightshoulder:b5,dpdown:b6,dpleft:b7,dpup:b8,dpright:b9,back:b10,start:b11,leftx:a0,lefty:a1,rightx:a2,righty:a3,",
+#endif
     "hidapi,*,a:b0,b:b1,back:b4,dpdown:b12,dpleft:b13,dpright:b14,dpup:b11,guide:b5,leftshoulder:b9,leftstick:b7,lefttrigger:a4,leftx:a0,lefty:a1,rightshoulder:b10,rightstick:b8,righttrigger:a5,rightx:a2,righty:a3,start:b6,x:b2,y:b3,",
     NULL
 };

--- a/src/main/psp/SDL_psp_main.c
+++ b/src/main/psp/SDL_psp_main.c
@@ -24,6 +24,7 @@
 */
 
 PSP_MODULE_INFO("SDL App", 0, 1, 1);
+PSP_MAIN_THREAD_ATTR(THREAD_ATTR_VFPU | THREAD_ATTR_USER);
 
 int sdl_psp_exit_callback(int arg1, int arg2, void *common)
 {

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -510,7 +510,7 @@ PSP_CreateTexture(SDL_Renderer * renderer, SDL_Texture * texture)
     PSP_TextureData* psp_texture = (PSP_TextureData*) SDL_calloc(1, sizeof(*psp_texture));
 
     if(!psp_texture)
-        return -1;
+        return SDL_OutOfMemory();
 
     psp_texture->swizzled = SDL_FALSE;
     psp_texture->width = texture->w;
@@ -1167,6 +1167,7 @@ PSP_DestroyTexture(SDL_Renderer * renderer, SDL_Texture * texture)
     if(psp_texture == 0)
         return;
 
+    LRUTargetRemove(renderdata, psp_texture);
     TextureStorageFree(psp_texture->data);
     SDL_free(psp_texture);
     texture->driverdata = NULL;

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -57,7 +57,7 @@ static unsigned int __attribute__((aligned(16))) DisplayList[262144];
 #define COL4444(r,g,b,a)    ((r>>4) | ((g>>4)<<4) | ((b>>4)<<8) | ((a>>4)<<12))
 #define COL8888(r,g,b,a)    ((r) | ((g)<<8) | ((b)<<16) | ((a)<<24))
 
-#define LOGGING
+//#define LOGGING
 #ifdef LOGGING
 #define LOG(...) printf(__VA_ARGS__)
 #else
@@ -213,15 +213,6 @@ LRUTargetRelink(PSP_TextureData* psp_texture) {
     }
 }
 
-/*static void
-LRUTargetFixTail(PSP_RenderData* data, PSP_TextureData* psp_texture) {
-    if(data->least_recent_target == psp_texture) {
-        data->least_recent_target = psp_texture->prevhotw;
-    } else if(!data->least_recent_target) {
-        data->least_recent_target = psp_texture;
-    }
-}*/
-
 static void
 LRUTargetPushFront(PSP_RenderData* data, PSP_TextureData* psp_texture) {
     LOG("Pushing %p (%dKB) front.\n", (void*)psp_texture, psp_texture->size / 1024);
@@ -255,7 +246,6 @@ LRUTargetBringFront(PSP_RenderData* data, PSP_TextureData* psp_texture) {
     if(data->most_recent_target == psp_texture) {
         return; //nothing to do
     }
-    //LRUTargetRelink(psp_texture);
     LRUTargetRemove(data, psp_texture);
     LRUTargetPushFront(data, psp_texture);
 }
@@ -907,7 +897,7 @@ StartDrawing(SDL_Renderer * renderer)
     if(!data->displayListAvail) {
         sceGuStart(GU_DIRECT, DisplayList);
         data->displayListAvail = SDL_TRUE;
-        ResetBlendState(&data->blendState);
+        //ResetBlendState(&data->blendState);
     }
 
     // Check if we need a draw buffer change
@@ -1284,7 +1274,6 @@ PSP_CreateRenderer(SDL_Window * window, Uint32 flags)
     void* doublebuffer = valloc(PSP_FRAME_BUFFER_SIZE*data->bpp*2);
     data->backbuffer = doublebuffer;
     data->frontbuffer = ((uint8_t*)doublebuffer)+PSP_FRAME_BUFFER_SIZE*data->bpp;
-    memset(&data->blendState, 0, sizeof(PSP_BlendState));
 
     sceGuInit();
     /* setup GU */
@@ -1307,16 +1296,8 @@ PSP_CreateRenderer(SDL_Window * window, Uint32 flags)
     sceGuFrontFace(GU_CCW);
     sceGuEnable(GU_CULL_FACE);
 
-    /* Texturing */
-    sceGuEnable(GU_TEXTURE_2D);
-    sceGuShadeModel(GU_SMOOTH);
-    sceGuTexWrap(GU_REPEAT, GU_REPEAT);
-
-    /* Blending */
-    //sceGuEnable(GU_BLEND);
-    //sceGuBlendFunc(GU_ADD, GU_SRC_ALPHA, GU_ONE_MINUS_SRC_ALPHA, 0, 0);
-
-    sceGuTexFilter(GU_LINEAR,GU_LINEAR);
+    //Setup initial blend state
+    ResetBlendState(&data->blendState);
 
     sceGuFinish();
     sceGuSync(0,0);

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -999,7 +999,6 @@ PSP_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *verti
 
             case SDL_RENDERCMD_SETVIEWPORT: {
                 SDL_Rect *viewport = &cmd->data.viewport.rect;
-                /* Viewport */
                 sceGuOffset(2048 - (viewport->w >> 1), 2048 - (viewport->h >> 1));
                 sceGuViewport(2048, 2048, viewport->w, viewport->h);
                 sceGuScissor(viewport->x, viewport->y, viewport->w, viewport->h);
@@ -1008,7 +1007,6 @@ PSP_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *verti
 
             case SDL_RENDERCMD_SETCLIPRECT: {
                 const SDL_Rect *rect = &cmd->data.cliprect.rect;
-                /* Scissoring */
                 if(cmd->data.cliprect.enabled){
                     sceGuEnable(GU_SCISSOR_TEST);
                     sceGuScissor(rect->x, rect->y, rect->w, rect->h);
@@ -1239,7 +1237,7 @@ PSP_CreateRenderer(SDL_Window * window, Uint32 flags)
     renderer->info.flags = (SDL_RENDERER_ACCELERATED | SDL_RENDERER_TARGETTEXTURE);
     renderer->driverdata = data;
     renderer->window = window;
-    
+
     if (data->initialized != SDL_FALSE)
         return 0;
     data->initialized = SDL_TRUE;
@@ -1259,14 +1257,10 @@ PSP_CreateRenderer(SDL_Window * window, Uint32 flags)
         case GU_PSM_4444:
         case GU_PSM_5650:
         case GU_PSM_5551:
-            //data->frontbuffer = (unsigned int *)(PSP_FRAME_BUFFER_SIZE<<1);
-            //data->backbuffer =  (unsigned int *)(0);
             data->bpp = 2;
             data->psm = pixelformat;
             break;
         default:
-            //data->frontbuffer = (unsigned int *)(PSP_FRAME_BUFFER_SIZE<<2);
-            //data->backbuffer =  (unsigned int *)(0);
             data->bpp = 4;
             data->psm = GU_PSM_8888;
             break;

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -57,6 +57,12 @@ static unsigned int __attribute__((aligned(16))) DisplayList[262144];
 #define COL4444(r,g,b,a)    ((r>>4) | ((g>>4)<<4) | ((b>>4)<<8) | ((a>>4)<<12))
 #define COL8888(r,g,b,a)    ((r) | ((g)<<8) | ((b)<<16) | ((a)<<24))
 
+//#define LOGGING
+#ifdef LOGGING
+#define LOG(...) printf(__VA_ARGS__)
+#else
+#define LOG(...)
+#endif
 /**
  * Holds psp specific texture data
  *
@@ -201,37 +207,31 @@ LRUTargetRelink(PSP_TextureData* psp_texture) {
     }
 }
 
-static void
+/*static void
 LRUTargetFixTail(PSP_RenderData* data, PSP_TextureData* psp_texture) {
     if(data->least_recent_target == psp_texture) {
         data->least_recent_target = psp_texture->prevhotw;
     } else if(!data->least_recent_target) {
         data->least_recent_target = psp_texture;
     }
-}
+}*/
 
 static void
 LRUTargetPushFront(PSP_RenderData* data, PSP_TextureData* psp_texture) {
+    LOG("Pushing %p (%dKB) front.\n", (void*)psp_texture, psp_texture->size / 1024);
     psp_texture->nexthotw = data->most_recent_target;
     if(data->most_recent_target) {
         data->most_recent_target->prevhotw = psp_texture;
     }
-    LRUTargetFixTail(data, psp_texture);
-}
-
-static void
-LRUTargetBringFront(PSP_RenderData* data, PSP_TextureData* psp_texture) {
-    if(data->most_recent_target == psp_texture) {
-        return; //nothing to do
+    data->most_recent_target = psp_texture;
+    if(!data->least_recent_target) {
+        data->least_recent_target = psp_texture;
     }
-    LRUTargetRelink(psp_texture);
-    psp_texture->prevhotw = NULL;
-    psp_texture->nexthotw = NULL;
-    LRUTargetPushFront(data, psp_texture);
 }
 
 static void
 LRUTargetRemove(PSP_RenderData* data, PSP_TextureData* psp_texture) {
+    LOG("Removing %p (%dKB).\n", (void*)psp_texture, psp_texture->size/1024);
     LRUTargetRelink(psp_texture);
     if(data->most_recent_target == psp_texture) {
         data->most_recent_target = psp_texture->nexthotw;
@@ -242,6 +242,37 @@ LRUTargetRemove(PSP_RenderData* data, PSP_TextureData* psp_texture) {
     psp_texture->prevhotw = NULL;
     psp_texture->nexthotw = NULL;
 }
+
+static void
+LRUTargetBringFront(PSP_RenderData* data, PSP_TextureData* psp_texture) {
+    LOG("Bringing %p (%dKB) front.\n", (void*)psp_texture, psp_texture->size/1024);
+    if(data->most_recent_target == psp_texture) {
+        return; //nothing to do
+    }
+    //LRUTargetRelink(psp_texture);
+    LRUTargetRemove(data, psp_texture);
+    LRUTargetPushFront(data, psp_texture);
+}
+
+#ifdef LOGGING
+static void
+LRUWalk(PSP_RenderData* data) {
+    PSP_TextureData* tex = data->most_recent_target;
+    LOG("================\nLRU STATE:\n");
+    size_t size = 0;
+    while(tex) {
+        LOG("Tex %p (%dKB)\n", (void*)tex, tex->size/1024);
+        size+= tex->size;
+        if(tex->nexthotw && tex->nexthotw->prevhotw != tex) {
+            LOG("Spurious link!\n");
+        }
+        tex = tex->nexthotw;
+    }
+    LOG("Total Size : %dKB\n", size/1024);
+    size_t latest_size = data->least_recent_target ? data->least_recent_target->size : 0;
+    LOG("Least recent %p (%dKB)\n================\n", data->least_recent_target, latest_size / 1024);
+}
+#endif
 
 static void
 TextureStorageFree(void* storage) {
@@ -412,13 +443,20 @@ TexturePromoteToVram(PSP_RenderData* data, PSP_TextureData* psp_texture, SDL_boo
 }
 
 static int
-TextureSpillLRU(PSP_RenderData* data) {
+TextureSpillLRU(PSP_RenderData* data, size_t wanted) {
     PSP_TextureData* lru = data->least_recent_target;
     if(lru) {
         if(TextureSpillToSram(data, lru) < 0) {
             return -1;
         }
+        LOG("Spilled %p (%dKB) to ram", (void*)lru, lru->size/1024);
         LRUTargetRemove(data, lru);
+        #ifdef LOGGING
+        LRUWalk(data);
+        #endif
+    } else {
+        SDL_SetError("Could not spill more VRAM to system memory. VRAM : %dKB,(%dKB), wanted %dKB", vmemavail()/1024, vlargestblock()/1024, wanted/1024);
+        return -1; //Asked to spill but there nothing to spill
     }
     return 0;
 }
@@ -427,7 +465,7 @@ static int
 TextureSpillTargetsForSpace(PSP_RenderData* data, size_t size)
 {
     while(vlargestblock() < size) {
-        if(TextureSpillLRU(data) < 0) {
+        if(TextureSpillLRU(data, size) < 0) {
             return -1;
         }
     }
@@ -446,6 +484,9 @@ TextureBindAsTarget(PSP_RenderData* data, PSP_TextureData* psp_texture) {
         }
     }
     LRUTargetBringFront(data, psp_texture);
+    #ifdef LOGGING
+    LRUWalk(data);
+    #endif
     sceGuDrawBufferList(psp_texture->format, vrelptr(psp_texture->data), psp_texture->textureWidth);
     return 0;
 }

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -302,6 +302,7 @@ TextureSwizzle(PSP_TextureData *psp_texture, void* dst)
     psp_texture->data = data;
     psp_texture->swizzled = SDL_TRUE;
 
+    sceKernelDcacheWritebackRange(psp_texture->data, psp_texture->size);
     return 1;
 }
 
@@ -332,8 +333,6 @@ TextureUnswizzle(PSP_TextureData *psp_texture, void* dst)
 
     if(!data)
         return SDL_OutOfMemory();
-
-    sceKernelDcacheWritebackAll();
 
     int j;
 
@@ -370,6 +369,7 @@ TextureUnswizzle(PSP_TextureData *psp_texture, void* dst)
 
     psp_texture->swizzled = SDL_FALSE;
 
+    sceKernelDcacheWritebackRange(psp_texture->data, psp_texture->size);
     return 1;
 }
 
@@ -387,6 +387,8 @@ TextureSpillToSram(PSP_RenderData* data, PSP_TextureData* psp_texture)
         SDL_memcpy(data, psp_texture->data, psp_texture->size);
         vfree(psp_texture->data);
         psp_texture->data = data;
+
+        sceKernelDcacheWritebackRange(psp_texture->data, psp_texture->size);
         return 0;
     } else {
         return TextureSwizzle(psp_texture, NULL); //Will realloc in sysram
@@ -404,6 +406,7 @@ TexturePromoteToVram(PSP_RenderData* data, PSP_TextureData* psp_texture, SDL_boo
         SDL_memcpy(tdata, psp_texture->data, psp_texture->size);
         SDL_free(psp_texture->data);
         psp_texture->data = tdata;
+        sceKernelDcacheWritebackRange(psp_texture->data, psp_texture->size);
         return 0;
     }
 }

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -57,7 +57,7 @@ static unsigned int __attribute__((aligned(16))) DisplayList[262144];
 #define COL4444(r,g,b,a)    ((r>>4) | ((g>>4)<<4) | ((b>>4)<<8) | ((a>>4)<<12))
 #define COL8888(r,g,b,a)    ((r) | ((g)<<8) | ((b)<<16) | ((a)<<24))
 
-//#define LOGGING
+#define LOGGING
 #ifdef LOGGING
 #define LOG(...) printf(__VA_ARGS__)
 #else
@@ -81,10 +81,17 @@ typedef struct PSP_TextureData
     unsigned int        format;                             /**< Image format - one of ::pgePixelFormat. */
     unsigned int        pitch;
     SDL_bool            swizzled;                           /**< Is image swizzled. */
-    struct PSP_TextureData*    prevhotw;                            /**< More recently used render target */
-    struct PSP_TextureData*    nexthotw;                            /**< Less recently used render target */
+    struct PSP_TextureData*    prevhotw;                    /**< More recently used render target */
+    struct PSP_TextureData*    nexthotw;                    /**< Less recently used render target */
 } PSP_TextureData;
 
+typedef struct
+{
+    SDL_BlendMode mode;
+    unsigned int color;
+    int shadeModel;
+    SDL_Texture* texture;
+} PSP_BlendState;
 
 typedef struct
 {
@@ -97,8 +104,7 @@ typedef struct
     unsigned int       bpp;                                 /**< bits per pixel of the main display */
 
     SDL_bool           vsync;                               /**< wether we do vsync */
-    unsigned int       currentColor;                        /**< current drawing color */
-    int                currentBlendMode;                    /**< current blend mode */
+    PSP_BlendState     blendState;                          /**< current blend mode */
     PSP_TextureData*   most_recent_target;                  /**< start of render target LRU double linked list */
     PSP_TextureData*   least_recent_target;                 /**< end of the LRU list */
 } PSP_RenderData;
@@ -160,7 +166,7 @@ Swap(float *a, float *b)
 static inline int
 InVram(void* data)
 {
-    return data < 0x04200000;
+    return data < (void*)0x04200000;
 }
 
 /* Return next power of 2 */
@@ -245,7 +251,7 @@ LRUTargetRemove(PSP_RenderData* data, PSP_TextureData* psp_texture) {
 
 static void
 LRUTargetBringFront(PSP_RenderData* data, PSP_TextureData* psp_texture) {
-    LOG("Bringing %p (%dKB) front.\n", (void*)psp_texture, psp_texture->size/1024);
+    //LOG("Bringing %p (%dKB) front.\n", (void*)psp_texture, psp_texture->size/1024);
     if(data->most_recent_target == psp_texture) {
         return; //nothing to do
     }
@@ -449,7 +455,7 @@ TextureSpillLRU(PSP_RenderData* data, size_t wanted) {
         if(TextureSpillToSram(data, lru) < 0) {
             return -1;
         }
-        LOG("Spilled %p (%dKB) to ram", (void*)lru, lru->size/1024);
+        LOG("Spilled %p (%dKB) to ram\n", (void*)lru, lru->size/1024);
         LRUTargetRemove(data, lru);
         #ifdef LOGGING
         LRUWalk(data);
@@ -484,10 +490,20 @@ TextureBindAsTarget(PSP_RenderData* data, PSP_TextureData* psp_texture) {
         }
     }
     LRUTargetBringFront(data, psp_texture);
-    #ifdef LOGGING
-    LRUWalk(data);
-    #endif
+    //LRUWalk(data);
     sceGuDrawBufferList(psp_texture->format, vrelptr(psp_texture->data), psp_texture->textureWidth);
+    // Stencil alpha dst hack
+    unsigned int dstFormat = psp_texture->format;
+    if(dstFormat == GU_PSM_5551) {
+        sceGuEnable(GU_STENCIL_TEST);
+        sceGuStencilOp(GU_REPLACE, GU_REPLACE, GU_REPLACE);
+        sceGuStencilFunc(GU_GEQUAL, 0xff, 0xff);
+        sceGuEnable(GU_ALPHA_TEST);
+        sceGuAlphaFunc(GU_GREATER, 0x00, 0xff);
+    } else {
+        sceGuDisable(GU_STENCIL_TEST);
+        sceGuDisable(GU_ALPHA_TEST);
+    }
     return 0;
 }
 
@@ -538,6 +554,9 @@ PSP_CreateTexture(SDL_Renderer * renderer, SDL_Texture * texture)
         psp_texture->data = valloc(psp_texture->size);
         if(psp_texture->data) {
             LRUTargetPushFront(data, psp_texture);
+            #ifdef LOGGING
+            LRUWalk(data);
+            #endif
         }
     } else {
         psp_texture->data = SDL_calloc(1, psp_texture->size);
@@ -580,13 +599,11 @@ TextureActivate(SDL_Texture * texture)
         TextureSwizzle(psp_texture, NULL);
     }
 
-    sceGuEnable(GU_TEXTURE_2D);
     sceGuTexWrap(GU_REPEAT, GU_REPEAT);
     sceGuTexMode(psp_texture->format, 0, 0, psp_texture->swizzled);
     sceGuTexFilter(scaleMode, scaleMode); /* GU_NEAREST good for tile-map */
                                           /* GU_LINEAR good for scaling */
     sceGuTexImage(0, psp_texture->textureWidth, psp_texture->textureHeight, psp_texture->textureWidth, psp_texture->data);
-    sceGuTexFunc(GU_TFX_REPLACE, GU_TCC_RGBA);
 }
 
 
@@ -870,6 +887,16 @@ PSP_QueueCopyEx(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture * t
     return 0;
 }
 
+static void
+ResetBlendState(PSP_BlendState* state) {
+    sceGuColor(0xffffffff);
+    state->color = 0xffffffff;
+    state->mode = SDL_BLENDMODE_INVALID;
+    state->texture = NULL;
+    sceGuDisable(GU_TEXTURE_2D);
+    sceGuShadeModel(GU_SMOOTH);
+    state->shadeModel = GU_SMOOTH;
+}
 
 static void
 StartDrawing(SDL_Renderer * renderer)
@@ -880,6 +907,7 @@ StartDrawing(SDL_Renderer * renderer)
     if(!data->displayListAvail) {
         sceGuStart(GU_DIRECT, DisplayList);
         data->displayListAvail = SDL_TRUE;
+        ResetBlendState(&data->blendState);
     }
 
     // Check if we need a draw buffer change
@@ -899,38 +927,59 @@ StartDrawing(SDL_Renderer * renderer)
 
 
 static void
-PSP_SetBlendMode(SDL_Renderer * renderer, int blendMode)
+PSP_SetBlendState(PSP_RenderData* data, PSP_BlendState* state)
 {
-    PSP_RenderData *data = (PSP_RenderData *) renderer->driverdata;
-    if (blendMode != data-> currentBlendMode) {
-        switch (blendMode) {
+    PSP_BlendState* current = &data->blendState;
+
+    if (state->mode != current->mode) {
+        switch (state->mode) {
         case SDL_BLENDMODE_NONE:
-                sceGuTexFunc(GU_TFX_REPLACE, GU_TCC_RGBA);
-                sceGuDisable(GU_BLEND);
+            sceGuTexFunc(GU_TFX_REPLACE, GU_TCC_RGBA);
+            sceGuDisable(GU_BLEND);
             break;
         case SDL_BLENDMODE_BLEND:
-                sceGuTexFunc(GU_TFX_MODULATE , GU_TCC_RGBA);
-                sceGuEnable(GU_BLEND);
-                sceGuBlendFunc(GU_ADD, GU_SRC_ALPHA, GU_ONE_MINUS_SRC_ALPHA, 0, 0 );
+            sceGuTexFunc(GU_TFX_MODULATE, GU_TCC_RGBA);
+            sceGuBlendFunc(GU_ADD, GU_SRC_ALPHA, GU_ONE_MINUS_SRC_ALPHA, 0, 0 );
+            sceGuEnable(GU_BLEND);
             break;
         case SDL_BLENDMODE_ADD:
-                sceGuTexFunc(GU_TFX_MODULATE , GU_TCC_RGBA);
-                sceGuEnable(GU_BLEND);
-                sceGuBlendFunc(GU_ADD, GU_SRC_ALPHA, GU_FIX, 0, 0x00FFFFFF );
+            sceGuTexFunc(GU_TFX_MODULATE , GU_TCC_RGBA);
+            sceGuBlendFunc(GU_ADD, GU_SRC_ALPHA, GU_FIX, 0, 0x00FFFFFF );
+            sceGuEnable(GU_BLEND);
             break;
         case SDL_BLENDMODE_MOD:
-                sceGuTexFunc(GU_TFX_MODULATE , GU_TCC_RGBA);
-                sceGuEnable(GU_BLEND);
-                sceGuBlendFunc(GU_ADD, GU_FIX, GU_SRC_COLOR, 0, 0);
+            sceGuTexFunc(GU_TFX_MODULATE , GU_TCC_RGBA);
+            sceGuBlendFunc(GU_ADD, GU_FIX, GU_SRC_COLOR, 0, 0);
+            sceGuEnable(GU_BLEND);
             break;
         case SDL_BLENDMODE_MUL:
-                sceGuTexFunc(GU_TFX_MODULATE , GU_TCC_RGBA);
-                sceGuEnable(GU_BLEND);
-                sceGuBlendFunc(GU_ADD, GU_DST_COLOR, GU_ONE_MINUS_SRC_ALPHA, 0, 0);
+            sceGuTexFunc(GU_TFX_MODULATE , GU_TCC_RGBA);
+            sceGuBlendFunc(GU_ADD, GU_DST_COLOR, GU_ONE_MINUS_SRC_ALPHA, 0, 0);
+            sceGuEnable(GU_BLEND);
+            break;
+        case SDL_BLENDMODE_INVALID:
             break;
         }
-        data->currentBlendMode = blendMode;
     }
+
+    if(state->color != current->color) {
+        sceGuColor(state->color);
+    }
+
+    if(state->shadeModel != current->shadeModel) {
+        sceGuShadeModel(state->shadeModel);
+    }
+
+    if(state->texture != current->texture) {
+        if(state->texture != NULL) {
+            TextureActivate(state->texture);
+            sceGuEnable(GU_TEXTURE_2D);
+        } else {
+            sceGuDisable(GU_TEXTURE_2D);
+        }
+    }
+
+    *current = *state;
 }
 
 static int
@@ -984,10 +1033,9 @@ PSP_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *verti
                 const Uint8 g = cmd->data.color.g;
                 const Uint8 b = cmd->data.color.b;
                 const Uint8 a = cmd->data.color.a;
-                const Uint32 color = ((a << 24) | (b << 16) | (g << 8) | r);
-                /* !!! FIXME: we could cache drawstate like clear color */
-                sceGuClearColor(color);
-                sceGuClear(GU_COLOR_BUFFER_BIT);//|GU_FAST_CLEAR_BIT);
+                sceGuClearColor(GU_RGBA(r,g,b,a));
+                sceGuClearStencil(a);
+                sceGuClear(GU_COLOR_BUFFER_BIT | GU_STENCIL_BUFFER_BIT);//|GU_FAST_CLEAR_BIT);
                 break;
             }
 
@@ -998,14 +1046,15 @@ PSP_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *verti
                 const Uint8 g = cmd->data.draw.g;
                 const Uint8 b = cmd->data.draw.b;
                 const Uint8 a = cmd->data.draw.a;
-                const Uint32 color = ((a << 24) | (b << 16) | (g << 8) | r);
-                /* !!! FIXME: we could cache draw state like color, texturing, etc */
-                sceGuColor(color);
-                sceGuDisable(GU_TEXTURE_2D);
-                sceGuShadeModel(GU_FLAT);
+
+                PSP_BlendState state = {
+                    .color = GU_RGBA(r,g,b,a),
+                    .texture = NULL,
+                    .mode = cmd->data.draw.blend,
+                    .shadeModel = GU_FLAT
+                };
+                PSP_SetBlendState(data, &state);
                 sceGuDrawArray(GU_POINTS, GU_VERTEX_32BITF|GU_TRANSFORM_2D, count, 0, verts);
-                sceGuShadeModel(GU_SMOOTH);
-                sceGuEnable(GU_TEXTURE_2D);
                 break;
             }
 
@@ -1016,14 +1065,14 @@ PSP_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *verti
                 const Uint8 g = cmd->data.draw.g;
                 const Uint8 b = cmd->data.draw.b;
                 const Uint8 a = cmd->data.draw.a;
-                const Uint32 color = ((a << 24) | (b << 16) | (g << 8) | r);
-                /* !!! FIXME: we could cache draw state like color, texturing, etc */
-                sceGuColor(color);
-                sceGuDisable(GU_TEXTURE_2D);
-                sceGuShadeModel(GU_FLAT);
+                PSP_BlendState state = {
+                    .color = GU_RGBA(r,g,b,a),
+                    .texture = NULL,
+                    .mode = cmd->data.draw.blend,
+                    .shadeModel = GU_FLAT
+                };
+                PSP_SetBlendState(data, &state);
                 sceGuDrawArray(GU_LINE_STRIP, GU_VERTEX_32BITF|GU_TRANSFORM_2D, count, 0, verts);
-                sceGuShadeModel(GU_SMOOTH);
-                sceGuEnable(GU_TEXTURE_2D);
                 break;
             }
 
@@ -1034,59 +1083,49 @@ PSP_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *verti
                 const Uint8 g = cmd->data.draw.g;
                 const Uint8 b = cmd->data.draw.b;
                 const Uint8 a = cmd->data.draw.a;
-                const Uint32 color = ((a << 24) | (b << 16) | (g << 8) | r);
-                /* !!! FIXME: we could cache draw state like color, texturing, etc */
-                sceGuColor(color);
-                sceGuDisable(GU_TEXTURE_2D);
-                sceGuShadeModel(GU_FLAT);
+                PSP_BlendState state = {
+                    .color = GU_RGBA(r,g,b,a),
+                    .texture = NULL,
+                    .mode = cmd->data.draw.blend,
+                    .shadeModel = GU_FLAT
+                };
+                PSP_SetBlendState(data, &state);
                 sceGuDrawArray(GU_SPRITES, GU_VERTEX_32BITF|GU_TRANSFORM_2D, 2 * count, 0, verts);
-                sceGuShadeModel(GU_SMOOTH);
-                sceGuEnable(GU_TEXTURE_2D);
                 break;
             }
 
             case SDL_RENDERCMD_COPY: {
                 const size_t count = cmd->data.draw.count;
                 const VertTV *verts = (VertTV *) (gpumem + cmd->data.draw.first);
-                const Uint8 alpha = cmd->data.draw.a;
-                TextureActivate(cmd->data.draw.texture);
-                PSP_SetBlendMode(renderer, cmd->data.draw.blend);
-
-                if(alpha != 255) {  /* !!! FIXME: is this right? */
-                    sceGuTexFunc(GU_TFX_MODULATE, GU_TCC_RGBA);
-                    sceGuColor(GU_RGBA(255, 255, 255, alpha));
-                } else {
-                    sceGuTexFunc(GU_TFX_REPLACE, GU_TCC_RGBA);
-                    sceGuColor(0xFFFFFFFF);
-                }
-
+                const Uint8 a = cmd->data.draw.a;
+                const Uint8 r = cmd->data.draw.r;
+                const Uint8 g = cmd->data.draw.g;
+                const Uint8 b = cmd->data.draw.b;
+                PSP_BlendState state = {
+                    .color = GU_RGBA(r,g,b,a),
+                    .texture = cmd->data.draw.texture,
+                    .mode = cmd->data.draw.blend,
+                    .shadeModel = GU_SMOOTH
+                };
+                PSP_SetBlendState(data, &state);
                 sceGuDrawArray(GU_SPRITES, GU_TEXTURE_32BITF|GU_VERTEX_32BITF|GU_TRANSFORM_2D, 2 * count, 0, verts);
-
-                if(alpha != 255) {
-                    sceGuTexFunc(GU_TFX_REPLACE, GU_TCC_RGBA);
-                }
                 break;
             }
 
             case SDL_RENDERCMD_COPY_EX: {
                 const VertTV *verts = (VertTV *) (gpumem + cmd->data.draw.first);
-                const Uint8 alpha = cmd->data.draw.a;
-                TextureActivate(cmd->data.draw.texture);
-                PSP_SetBlendMode(renderer, cmd->data.draw.blend);
-
-                if(alpha != 255) {  /* !!! FIXME: is this right? */
-                    sceGuTexFunc(GU_TFX_MODULATE, GU_TCC_RGBA);
-                    sceGuColor(GU_RGBA(255, 255, 255, alpha));
-                } else {
-                    sceGuTexFunc(GU_TFX_REPLACE, GU_TCC_RGBA);
-                    sceGuColor(0xFFFFFFFF);
-                }
-
+                const Uint8 a = cmd->data.draw.a;
+                const Uint8 r = cmd->data.draw.r;
+                const Uint8 g = cmd->data.draw.g;
+                const Uint8 b = cmd->data.draw.b;
+                PSP_BlendState state = {
+                    .color = GU_RGBA(r,g,b,a),
+                    .texture = cmd->data.draw.texture,
+                    .mode = cmd->data.draw.blend,
+                    .shadeModel = GU_SMOOTH
+                };
+                PSP_SetBlendState(data, &state);
                 sceGuDrawArray(GU_TRIANGLE_FAN, GU_TEXTURE_32BITF|GU_VERTEX_32BITF|GU_TRANSFORM_2D, 4, 0, verts);
-
-                if(alpha != 255) {
-                    sceGuTexFunc(GU_TFX_REPLACE, GU_TCC_RGBA);
-                }
                 break;
             }
 
@@ -1245,6 +1284,7 @@ PSP_CreateRenderer(SDL_Window * window, Uint32 flags)
     void* doublebuffer = valloc(PSP_FRAME_BUFFER_SIZE*data->bpp*2);
     data->backbuffer = doublebuffer;
     data->frontbuffer = ((uint8_t*)doublebuffer)+PSP_FRAME_BUFFER_SIZE*data->bpp;
+    memset(&data->blendState, 0, sizeof(PSP_BlendState));
 
     sceGuInit();
     /* setup GU */
@@ -1273,8 +1313,8 @@ PSP_CreateRenderer(SDL_Window * window, Uint32 flags)
     sceGuTexWrap(GU_REPEAT, GU_REPEAT);
 
     /* Blending */
-    sceGuEnable(GU_BLEND);
-    sceGuBlendFunc(GU_ADD, GU_SRC_ALPHA, GU_ONE_MINUS_SRC_ALPHA, 0, 0);
+    //sceGuEnable(GU_BLEND);
+    //sceGuBlendFunc(GU_ADD, GU_SRC_ALPHA, GU_ONE_MINUS_SRC_ALPHA, 0, 0);
 
     sceGuTexFilter(GU_LINEAR,GU_LINEAR);
 

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -568,7 +568,7 @@ PSP_QueueCopy(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture * tex
 
         cmd->data.draw.count = count;
 
-        verts = (VertTV *) SDL_AllocateRenderVertices(renderer, count * sizeof (VertTV), 4, &cmd->data.draw.first);
+        verts = (VertTV *) SDL_AllocateRenderVertices(renderer, count * 2 * sizeof (VertTV), 4, &cmd->data.draw.first);
         if (!verts) {
             return -1;
         }
@@ -586,6 +586,7 @@ PSP_QueueCopy(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture * tex
             verts->x = curX;
             verts->y = y;
             verts->z = 0;
+            verts++;
 
             curU += sourceWidth;
             curX += polyWidth;
@@ -595,6 +596,7 @@ PSP_QueueCopy(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture * tex
             verts->x = curX;
             verts->y = (y + height);
             verts->z = 0;
+            verts++;
         }
     }
 

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -229,6 +229,7 @@ PSP_CreateWindow(_THIS, SDL_Window * window)
     /* Setup driver data for this window */
     window->driverdata = wdata;
 
+    SDL_SetKeyboardFocus(window);
 
     /* Window has been successfully created */
     return 0;

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -173,7 +173,6 @@ PSP_VideoInit(_THIS)
     current_mode.refresh_rate = 60;
     /* 32 bpp for default */
     current_mode.format = SDL_PIXELFORMAT_ABGR8888;
-
     current_mode.driverdata = NULL;
 
     SDL_zero(display);
@@ -181,8 +180,15 @@ PSP_VideoInit(_THIS)
     display.current_mode = current_mode;
     display.driverdata = NULL;
 
-    SDL_AddVideoDisplay(&display);
+    SDL_AddDisplayMode(&display, &current_mode);
 
+    /* 16 bpp secondary mode */
+    current_mode.format = SDL_PIXELFORMAT_BGR565;
+    display.desktop_mode = current_mode;
+    display.current_mode = current_mode;
+    SDL_AddDisplayMode(&display, &current_mode);
+
+    SDL_AddVideoDisplay(&display);
     return 1;
 }
 


### PR DESCRIPTION
This fixes the behavior of the renderer. Making it behave like 2.0.9.
There are still changes that are to be made : 
- [x] Support render to texture
- [x] Support spilling render textures to sys RAM
- [x] Support for 16bit display instead of 32bit default
- [x] Support for color modulation, alpha modulation